### PR TITLE
feat: using first genesis account as executor address

### DIFF
--- a/genesis/genesis.json
+++ b/genesis/genesis.json
@@ -1521,7 +1521,7 @@
     ]
   },
   "params": {
-    "executorAddress": "0x0000000000000000000000004578656375746f72",
+    "executorAddress": "0xACe34e75980314a7bf79Cfa6C329CC8D05f8044c",
     "baseGasPrice": 10000000000000,
     "rewardRatio": "300000000000000000",
     "proposerEndorsement": "25000000000000000000000000"

--- a/scripts/generate-genesis.js
+++ b/scripts/generate-genesis.js
@@ -248,7 +248,7 @@ const main = async () => {
   }
 
   genesis.params = {
-    executorAddress: "0x0000000000000000000000004578656375746f72",
+    executorAddress: genesisAccounts[0].address,
     baseGasPrice: 10000000000000,
     rewardRatio: 300000000000000000n,
     proposerEndorsement: 25000000000000000000000000n,


### PR DESCRIPTION
## Describe your changes

Making the first account the executor account so we can set params easily (no need of further funding)
